### PR TITLE
Fix broken reference to GAP Packages chapter.

### DIFF
--- a/doc/singular.xml
+++ b/doc/singular.xml
@@ -329,7 +329,8 @@ the core part of &GAP; and some of the &GAP; packages.
 
 The package <Package>singular</Package> is installed and loaded as a
 normal &GAP; package: see the &GAP; documentation
-<Ref Chap="GAP Packages" BookName="ref"/>.
+<Ref Sect="Installing a GAP Package" BookName="ref"/> and
+<Ref Sect="Loading a GAP Package" BookName="ref"/>.
 
 <P/>
 


### PR DESCRIPTION
There is no "GAP Packages" chapter in the gap 4.10.2 manual.  Since the sentence refers to installing and loading packages, refer to the corresponding sections instead.