### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/doc/singular.xml
+++ b/doc/singular.xml
@@ -894,10 +894,10 @@ gap> I:= Ideal( R, [f,g] );;
 gap> SingularLibrary( "primdec.lib" );
 gap> SingularInterface( "primdecGTZ", [ I ], "def" );
 #I  Singular output of type "list"
-[ [ &lt;two-sided ideal in Rationals[x,y,z], (1 generators)>,
-      &lt;two-sided ideal in Rationals[x,y,z], (1 generators)> ],
-  [ &lt;two-sided ideal in Rationals[x,y,z], (1 generators)>,
-      &lt;two-sided ideal in Rationals[x,y,z], (1 generators)> ],
+[ [ &lt;two-sided ideal in Rationals[x,y,z], (1 generator)>,
+      &lt;two-sided ideal in Rationals[x,y,z], (1 generator)> ],
+  [ &lt;two-sided ideal in Rationals[x,y,z], (1 generator)>,
+      &lt;two-sided ideal in Rationals[x,y,z], (1 generator)> ],
   [ &lt;two-sided ideal in Rationals[x,y,z], (2 generators)>,
       &lt;two-sided ideal in Rationals[x,y,z], (2 generators)> ],
   [ &lt;two-sided ideal in Rationals[x,y,z], (3 generators)>,

--- a/tst/testall.tst
+++ b/tst/testall.tst
@@ -196,18 +196,12 @@ x^3*y^2*z+x^2*y^3*z+x^2*y^2*z^2-x^2*y*z^2-x*y^2*z^2-x*y*z^3
 gap> I:= Ideal( R, [f,g] );
 <two-sided ideal in Rationals[x,y,z], (2 generators)>
 gap> SingularLibrary("primdec.lib");
-gap> pd:=SingularInterface("primdecGTZ", [ I ], "def" );
+gap> pd:=SingularInterface("primdecGTZ", [ I ], "def" );;
 #I  running SingularInterface( "primdecGTZ", [ "ideal" ], "def" )...
 #I  done SingularInterface.
 #I  Singular output of type "list"
-[ [ <two-sided ideal in Rationals[x,y,z], (1 generators)>, 
-      <two-sided ideal in Rationals[x,y,z], (1 generators)> ], 
-  [ <two-sided ideal in Rationals[x,y,z], (1 generators)>, 
-      <two-sided ideal in Rationals[x,y,z], (1 generators)> ], 
-  [ <two-sided ideal in Rationals[x,y,z], (2 generators)>, 
-      <two-sided ideal in Rationals[x,y,z], (2 generators)> ], 
-  [ <two-sided ideal in Rationals[x,y,z], (3 generators)>, 
-      <two-sided ideal in Rationals[x,y,z], (2 generators)> ] ]
+gap> Length(pd);
+4
 gap> List(pd,x->List(x,GeneratorsOfTwoSidedIdeal));
 [ [ [ x*y-z ], [ x*y-z ] ], [ [ z ], [ z ] ], 
   [ [ y^2+y*z+z^2, x+y+z ], [ y^2+y*z+z^2, x+y+z ] ], 


### PR DESCRIPTION
In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` for `CyclicGroup(3);` will change from `<pc group of size 3 with 1 generators>` to `<pc group of size 3 with 1 generator>`.

The changes in this PR maintain the backwards and forwards compatibility of this package with GAP.

See gap-system/gap#3992 and gap-system/gap#4050 for more context.